### PR TITLE
Density of Icon image specified

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -18,7 +18,10 @@
     <allow-intent href="geo:*" />
     <platform name="android">
         <allow-intent href="market:*" />
-	<icon src="res/icon/android/library-icon.png">
+	<icon src="res/icon/android/library-icon.png" density="ldpi">
+	<icon src="res/icon/android/library-icon.png" density="mdpi">
+	<icon src="res/icon/android/library-icon.png" density="hdpi">
+	<icon src="res/icon/android/library-icon.png" density="xhdpi">
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />


### PR DESCRIPTION
Cordova failed to run since density parameter was not specified